### PR TITLE
Avoid creating an OnlineService with null AccountBook

### DIFF
--- a/core/src/main/resources/com/moneydance/modules/features/paypalimporter/meta_info.dict
+++ b/core/src/main/resources/com/moneydance/modules/features/paypalimporter/meta_info.dict
@@ -1,6 +1,6 @@
 {
   "vendor" = "Florian J. Breunig"
-  "module_build" = "10"
+  "module_build" = "11"
   "minbuild" = "1000"
   "vendor.url" = "https://www.my-flow.com/paypalimporter/"
   "module_name" = "PayPal Importer"


### PR DESCRIPTION
in Moneydance 2023.2 and up, every MoneydanceSyncableItem including OnlineService needs to be constructed with a non-null AccountBook.  This PR does that by creating the OnlineService lazily when an AccountBook is available.