### PR TITLE
Update JUnit dependencies to version 5.10.4

### DIFF
--- a/support/build.gradle
+++ b/support/build.gradle
@@ -7,8 +7,8 @@ dependencies {
     runtimeOnly('com.syncthemall:dropbox-java-sdk:1.5.3.2')
     runtimeOnly(':com.sun.net.ssl:')
 
-    testImplementation('org.junit.jupiter:junit-jupiter:5.10.2')
-    testImplementation('org.junit.vintage:junit-vintage-engine:5.10.2') // For backward compatibility with JUnit 4 tests
+    testImplementation('org.junit.jupiter:junit-jupiter:5.10.4')
+    testImplementation('org.junit.vintage:junit-vintage-engine:5.10.4') // For backward compatibility with JUnit 4 tests
 
     testRuntimeOnly('org.slf4j:slf4j-simple:2.0.17')
 }


### PR DESCRIPTION
## Summary
- Merge PR #91 and #88 into a single update that bumps both JUnit Jupiter and JUnit Vintage dependencies from 5.10.2 to 5.10.4
- Maintains compatibility with existing test infrastructure while providing latest patches and bug fixes

## Test plan
- [x] All 140 tests pass
- [x] Code quality checks (Checkstyle, PMD, SpotBugs) pass
- [x] Build and assembly successful

This consolidates two separate dependency PRs (#91 and #88) into a single coherent update.